### PR TITLE
Avoid duplicating entries in database table because of storing only filename and checking for entire path

### DIFF
--- a/Model/Behavior/UploadBehavior.php
+++ b/Model/Behavior/UploadBehavior.php
@@ -240,10 +240,10 @@ class UploadBehavior extends ModelBehavior {
 				'foreign_key' => $model->id,
 				'model' => $model->alias,
 				'type' => $type,
-				'filename' => $filename,
+				'filename' => basename($filename),
 			),
 		));
-
+		
 		$data = array(
 			$className => array(
 				'model' => $model->alias,


### PR DESCRIPTION
If you upload an image a second time, the row in the database is duplicated because the stored filename is

image.jpg

while when checking if the record already exists it checks for the full path

/var/www/site/webroot/upload/image/image.jpg
