### PR TITLE
Adding cast to solve incompatible method error

### DIFF
--- a/Model/Behavior/UploadBehavior.php
+++ b/Model/Behavior/UploadBehavior.php
@@ -416,7 +416,7 @@ class UploadBehavior extends ModelBehavior
      * @return mixed False if the operation should abort. Any other result will continue.
      * @access public
      */
-    public function beforeDelete($model, $cascade = true)
+    public function beforeDelete(Model $model, $cascade = true)
     {
         if ($cascade = true) {
             foreach ($this->types[$model->alias] as $type) {


### PR DESCRIPTION
In PHP 5.4.x there is a strict error saying that the beforeDelete method is incompatible with the parent class. This happens because in the parameters, the parent class has a cast, that the child class didn't had.
