### PR TITLE
Make possible define a method to custom filenames

### DIFF
--- a/Model/Behavior/UploadBehavior.php
+++ b/Model/Behavior/UploadBehavior.php
@@ -326,7 +326,7 @@ class UploadBehavior extends ModelBehavior
      * @return string File extension
      * @access public
      */
-    public function getFileExtension($file)
+    public function getFileExtension(Model $model, $file)
     {
         return strtolower(pathinfo($file, PATHINFO_EXTENSION));
     }
@@ -472,7 +472,7 @@ class UploadBehavior extends ModelBehavior
             return;
         }
 
-        $file   = $this->generateName($model, $type, $index);
+        $file   = $model->generateName($type, $index);
         $attach = $this->saveAttachment($model, $type, $file);
 
         if (!empty($uploadData['tmp_name'])) {
@@ -597,15 +597,16 @@ class UploadBehavior extends ModelBehavior
      */
     public function generateName(Model $model, $type, $index = null)
     {
-
         $dir = $this->getUploadFolder($model, $type);
 
         if (is_null($index)) {
             $extension = $this->getFileExtension(
+                $model,
                 $model->data[$model->alias][$type]['name']
             );
         } else {
             $extension = $this->getFileExtension(
+                $model,
                 $model->data[$model->alias][$type][$index]['name']
             );
         }


### PR DESCRIPTION
Using the Cake Behavior's behavior the idea here is make possible to write a method in the model itself. It was already possible to custom the filename using the $actsAs attribute like:

``` php
public $actsAs = array(
    'Attach.Upload' => array(
        'xml' => array(
            'dir' => 'webroot{DS}files{DS}news',
            'filename' => 'not-so-cool-custom-name'
        )
    )
);
```

Its still working but will be overwritten in case you implement your custom method in the specific model like:

``` php
public function generateName($type, $index = null)
{
    $dir = $this->getUploadFolder($type);

    $customName = 'xmlReallyCoolCustom';

    if (is_null($index)) {

        $clientName = $this->data[$this->alias][$type]['name'];

        $extension = $this->getFileExtension(
            $clientName
        );

    } else {
        $extension = $this->getFileExtension(
            $this->data[$this->alias][$type][$index]['name']
        );
    }

    if (!is_null($index)) {
        return $dir 
            . $type 
            . '_' 
            . $index 
            . '_' 
            . $this->id 
            . '.' 
            . $extension;
    }

    return $dir . $customName . '_' . $this->id  . '.' . $extension;
}
```

As we still receive $type parameter we could handle multiple file inside our custom method through some logic (switches, if's...) and if the model doesn't have this method the default name, from Behavior, will be used.

What do you think about it? Hope it helps!
