### PR TITLE
Fixed a bug in the relation when the type uses underscore. It was using strtolower...

### DIFF
--- a/Model/Behavior/UploadBehavior.php
+++ b/Model/Behavior/UploadBehavior.php
@@ -87,7 +87,7 @@ class UploadBehavior extends ModelBehavior
 			'dependent' => true,
 			'conditions' => array(
 				'Attachment' . $type . '.model' => $model->alias,
-				'Attachment' . $type . '.type' => strtolower($type)),
+				'Attachment' . $type . '.type' => Inflector::underscore($type)),
 			'fields' => '',
 			'order' => ''
 		);


### PR DESCRIPTION
... to set the type inside the conditions array, but since it has used Inflector::camelize before, it needs to use Inflector::underscore to get the correct value.
